### PR TITLE
Add ** to fix deprecation warnings for ruby-2.7.0

### DIFF
--- a/sunspot_rails/lib/sunspot/rails/searchable.rb
+++ b/sunspot_rails/lib/sunspot/rails/searchable.rb
@@ -264,7 +264,7 @@ module Sunspot #:nodoc:
 
           if options[:batch_size].to_i > 0
             batch_counter = 0
-            self.includes(options[:include]).find_in_batches(options.slice(:batch_size, :start)) do |records|
+            self.includes(options[:include]).find_in_batches(**options.slice(:batch_size, :start)) do |records|
 
               solr_benchmark(options[:batch_size], batch_counter += 1) do
                 Sunspot.index(records.select(&:indexable?))


### PR DESCRIPTION

Ruby: https://www.ruby-lang.org/en/news/2019/12/25/ruby-2-7-0-released/
Refer: https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/